### PR TITLE
Allow multiple envs in ~/.emacs.d/python-environments/

### DIFF
--- a/python-environment.el
+++ b/python-environment.el
@@ -35,7 +35,7 @@
 (defconst python-environment-version "0.0.0")
 
 (defcustom python-environment-directory
-  (locate-user-emacs-file "python-environments")
+  (locate-user-emacs-file ".python-environments")
   "Path to directory to store all Python virtual environments"
   :group 'python-environment)
 
@@ -43,7 +43,7 @@
   "Default Python virtual environment name.
 This is a name of directory relative to `python-environment-directory'.
 Thus, typically the default virtual environment path is
-``~/.emacs.d/python-environments/default``."
+``~/.emacs.d/.python-environments/default``."
   :group 'python-environment)
 
 (defcustom python-environment-virtualenv

--- a/test-python-environment.el
+++ b/test-python-environment.el
@@ -107,7 +107,7 @@ variable can be given as ENVIRONMENT (see `pye-with-mixed-environment')."
     (pye-eval-in-subprocess '(deferred:sync! (python-environment-make))
                             `(("HOME" ,tmp-home)))
     (should (file-directory-p (expand-file-name
-                               ".emacs.d/python-environments/default"
+                               ".emacs.d/.python-environments/default"
                                tmp-home)))))
 
 (provide 'test-python-environment)


### PR DESCRIPTION
Difference to the current master is that with this patch, `~/.emacs.d/python-environments/ROOT-NAME` is the path to virtualenv rather than `~/.emacs.d/python-environment/`.  Emacs packages using python-environment.el should put env in `~/.emacs.d/python-environments/SOME-NAME` or just default location `~/.emacs.d/python-environments/default`.  This way, user just have to change `python-environment-directory` to change path to all virtualenv.

This is 90% in and final concern before the first release.  I am trying to think about demerit. If I can't find a big one, then this is in.
